### PR TITLE
fix(webp): GIFがループしない問題を修正

### DIFF
--- a/src/image-processor.ts
+++ b/src/image-processor.ts
@@ -23,6 +23,7 @@ export const webpDefault: sharp.WebpOptions = {
     smartSubsample: true,
     mixed: true,
     effort: 2,
+    loop: 0,
 };
 
 export function convertToWebpStream(path: string, width: number, height: number, options: sharp.WebpOptions = webpDefault): IImageStream {


### PR DESCRIPTION
ref: https://github.com/lovell/sharp/issues/3394

TODO: sharp v0.34.2 がリリースされたら設定を見直す

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - WebPエンコード設定に「ループ」オプション（loop: 0）が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->