### PR TITLE
fix(webp): GIFがループしない問題を修正2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/misskey-dev/media-proxy/issues"
   },
   "homepage": "https://github.com/misskey-dev/media-proxy#readme",
+  "resolutions": {
+    "sharp": "0.34.0-rc.0"
+  },
   "devDependencies": {
     "@swc/cli": "0.7.7",
     "@swc/core": "1.11.24",
@@ -51,7 +54,7 @@
     "is-svg": "6.0.0",
     "pino": "9.6.0",
     "private-ip": "3.0.2",
-    "sharp": "0.34.1",
+    "sharp": "0.34.0-rc.0",
     "tmp": "0.2.3"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  sharp: 0.34.0-rc.0
+
 importers:
 
   .:
@@ -51,8 +54,8 @@ importers:
         specifier: 3.0.2
         version: 3.0.2
       sharp:
-        specifier: 0.34.1
-        version: 0.34.1
+        specifier: 0.34.0-rc.0
+        version: 0.34.0-rc.0
       tmp:
         specifier: 0.2.3
         version: 0.2.3
@@ -123,112 +126,112 @@ packages:
   '@file-type/xml@0.4.3':
     resolution: {integrity: sha512-pGRmkHf+NofNy/52r06HOTsEwdNnBsFEhN6U95s33P+ezuoxZEyBTV9lOB1/Zr0So6/9vDVfWZXLpgd0fy8cOQ==}
 
-  '@img/sharp-darwin-arm64@0.34.1':
-    resolution: {integrity: sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==}
+  '@img/sharp-darwin-arm64@0.34.0-rc.0':
+    resolution: {integrity: sha512-qbkTsi4yItqb+bvi3JVbgIVPixk4sz7r1F5aw80vzK+q0yHj9lTFYkqnqWhCGNggp3MZfwx4Gqre5M+Y9ITwwQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.1':
-    resolution: {integrity: sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q==}
+  '@img/sharp-darwin-x64@0.34.0-rc.0':
+    resolution: {integrity: sha512-aOLXjFWhVcBUpDIWFAZ1AalJKXpm0d1vRQ5alAqTYFZgLwOk80LTEXWy32TQqRUQlHIiUBVq4Aw1KcwvFgPM7Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.1.0':
-    resolution: {integrity: sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==}
+  '@img/sharp-libvips-darwin-arm64@1.1.0-rc4':
+    resolution: {integrity: sha512-AVPOee9ZyJ5MfS1Iuyx1M2VKHHKnL+kFFp1fWt3QqBWuTVs3JR8ApJOOdmY/Y8Z9sR1eQ3EHsCrzfKCcLxTMRg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.1.0':
-    resolution: {integrity: sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==}
+  '@img/sharp-libvips-darwin-x64@1.1.0-rc4':
+    resolution: {integrity: sha512-m2etL2MOBqAp7e7fjJqktTQW13gSY+XQ1rXlQ+AzxviASMhQdpRxPeQgtX7lwnsUL+4S/blRrjh+gVL1LnlsgA==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.1.0':
-    resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
+  '@img/sharp-libvips-linux-arm64@1.1.0-rc4':
+    resolution: {integrity: sha512-27/wAovlMES4A0dFMRaACcoytVHtQc8QcptQwJBOZHF6IeGPsq6WN3RqDDRNs+T9O7WV+ivALLjCCDIHxXA3Zw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.1.0':
-    resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
+  '@img/sharp-libvips-linux-arm@1.1.0-rc4.1':
+    resolution: {integrity: sha512-GvScbEYBFtNMXJuIjXtKCuod66NN52sS2MJEiNQZyEly5aoaJACYnjyszwBfGQTkuxx2Sr2Wv2vTJhtsomCBGA==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.1.0':
-    resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
+  '@img/sharp-libvips-linux-ppc64@1.1.0-rc4':
+    resolution: {integrity: sha512-bXCe1kN7ZoC6f+aryXYpi+SEIGFmWxQxa1IQ8XBh3RgtsUiWF8/yfPtYyUHRIt4RXVNABEcpaSvHrtMqunTPQA==}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.1.0':
-    resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
+  '@img/sharp-libvips-linux-s390x@1.1.0-rc4':
+    resolution: {integrity: sha512-OpVPJ8XfmrwQ5txkzdCliT57IBrFBBF4EqwrLdq9SqeUtnyM2GlgQf+3TRTmnh3LT4HGC/13VgBmYgWXxTv8cw==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.1.0':
-    resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
+  '@img/sharp-libvips-linux-x64@1.1.0-rc4':
+    resolution: {integrity: sha512-Wo3OjH0RaQrhAnSiNv8IvunVSzg73n7WxzmxnwzyHW9pooDzDfF9CnRpIW6KD84Sj/LRLT+ZuaU5ro4b4tYv4A==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
-    resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.1.0-rc4':
+    resolution: {integrity: sha512-cftYedmpewmg6STcGp63W09RAXVDQXZaAmlw7/8cMnH7q/XJKPmWVdQW3TWDNd7Ag7Z1ZF5zJ4C2N8+84eBX7g==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.1.0':
-    resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
+  '@img/sharp-libvips-linuxmusl-x64@1.1.0-rc4':
+    resolution: {integrity: sha512-wqfQrWDbwuPu5XWPNIizZ49q8jXFWlp4zBENG7JwzXEP+BIpT4aQbw92Oaep1bXZF7zXaQjowm6c+ifU5aVG2Q==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.1':
-    resolution: {integrity: sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==}
+  '@img/sharp-linux-arm64@0.34.0-rc.0':
+    resolution: {integrity: sha512-BGIQ198i7vRidGUw9vXCiq1cOeihCRaryZUKyk+nnC5NgjXi4MGGDUuMtIO9oWc0m82uxEAh1Anv2Gob7nL7Bw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.1':
-    resolution: {integrity: sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==}
+  '@img/sharp-linux-arm@0.34.0-rc.0':
+    resolution: {integrity: sha512-zEyjTaR8L1NigTkuZ4+aOQKFhqJmaum/0B8y4KrJf4veRCDIWUWemMEMTG5y0U8unIsyhPi3HKXSqAHARvie4A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.1':
-    resolution: {integrity: sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==}
+  '@img/sharp-linux-s390x@0.34.0-rc.0':
+    resolution: {integrity: sha512-zjcm7vPxPqIfKE5XbSvwMYc7ZYA7GZmCW2+o/B5i5DhoomLrx4IlBjt7+L4WykMdQkrYkDaFmTRORoD6/Veh6g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.1':
-    resolution: {integrity: sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==}
+  '@img/sharp-linux-x64@0.34.0-rc.0':
+    resolution: {integrity: sha512-XO+D78ZrbYYHiBaqXDkc+vHWlRAn1k03hVhkPxpLyEEAN7gHGfIFVBPlE2yZhbMloqEW41zfIpSY6Vg8SS1poQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.1':
-    resolution: {integrity: sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==}
+  '@img/sharp-linuxmusl-arm64@0.34.0-rc.0':
+    resolution: {integrity: sha512-CqYOm0aOg+6+Ep7Dbtl5/V9Ll8u5aGK/e6XLVSZLMsJ+Bfh02NnYVDJZhYZPh1QmvnqUJwCX8egIL4lpiMPuCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.1':
-    resolution: {integrity: sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==}
+  '@img/sharp-linuxmusl-x64@0.34.0-rc.0':
+    resolution: {integrity: sha512-DIbS0nAMAmKsLxCvtoQSFpMWbk4G460kb0axjL4M3oaRCEcXCPwa2gsgiVwoy6YYxCxBBDyzgQt4AggLEMpSXA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.1':
-    resolution: {integrity: sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==}
+  '@img/sharp-wasm32@0.34.0-rc.0':
+    resolution: {integrity: sha512-8mUPtwQXmw5YbUJMZjIhtuF+MpX+8ib2aQ4f143y5EFi4yej3qzNw8yxWUaor3VxaZMJNwTgG23K75Hj0eymTw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-ia32@0.34.1':
-    resolution: {integrity: sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw==}
+  '@img/sharp-win32-ia32@0.34.0-rc.0':
+    resolution: {integrity: sha512-HvKmPPepuoJb7bzv8aRR13/WVN2YPhcgdb6R9w5z8i08Eijglb5gzB+z4/ajRvPjC6GCn121/XLtM59b5HzDQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.1':
-    resolution: {integrity: sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw==}
+  '@img/sharp-win32-x64@0.34.0-rc.0':
+    resolution: {integrity: sha512-4buOejyM4w+TsTHyYSXXxwPY4hsHmoZhJLlasF8/TiqeiSMr7rprJ/4PtCCaSfF+Y6HdhCDFBUpispDUxLky2g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -1178,11 +1181,6 @@ packages:
     resolution: {integrity: sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==}
     engines: {node: '>=12'}
 
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
@@ -1194,8 +1192,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.34.1:
-    resolution: {integrity: sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==}
+  sharp@0.34.0-rc.0:
+    resolution: {integrity: sha512-Cxt2swo5T3Qb3raVkkxHV3k6ef5pRAgtyGgziw08tl+JXWc9/Cwch8LxlzyYU/pJZePYsfW5NFe5kAX0lxWMng==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
@@ -1427,82 +1425,82 @@ snapshots:
       sax: 1.4.1
       strtok3: 10.2.2
 
-  '@img/sharp-darwin-arm64@0.34.1':
+  '@img/sharp-darwin-arm64@0.34.0-rc.0':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.1.0
+      '@img/sharp-libvips-darwin-arm64': 1.1.0-rc4
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.1':
+  '@img/sharp-darwin-x64@0.34.0-rc.0':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.1.0
+      '@img/sharp-libvips-darwin-x64': 1.1.0-rc4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.1.0':
+  '@img/sharp-libvips-darwin-arm64@1.1.0-rc4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.1.0':
+  '@img/sharp-libvips-darwin-x64@1.1.0-rc4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.1.0':
+  '@img/sharp-libvips-linux-arm64@1.1.0-rc4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.1.0':
+  '@img/sharp-libvips-linux-arm@1.1.0-rc4.1':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.1.0':
+  '@img/sharp-libvips-linux-ppc64@1.1.0-rc4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.1.0':
+  '@img/sharp-libvips-linux-s390x@1.1.0-rc4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.1.0':
+  '@img/sharp-libvips-linux-x64@1.1.0-rc4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
+  '@img/sharp-libvips-linuxmusl-arm64@1.1.0-rc4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.1.0':
+  '@img/sharp-libvips-linuxmusl-x64@1.1.0-rc4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.1':
+  '@img/sharp-linux-arm64@0.34.0-rc.0':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.1.0
+      '@img/sharp-libvips-linux-arm64': 1.1.0-rc4
     optional: true
 
-  '@img/sharp-linux-arm@0.34.1':
+  '@img/sharp-linux-arm@0.34.0-rc.0':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.1.0
+      '@img/sharp-libvips-linux-arm': 1.1.0-rc4.1
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.1':
+  '@img/sharp-linux-s390x@0.34.0-rc.0':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.1.0
+      '@img/sharp-libvips-linux-s390x': 1.1.0-rc4
     optional: true
 
-  '@img/sharp-linux-x64@0.34.1':
+  '@img/sharp-linux-x64@0.34.0-rc.0':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.1.0
+      '@img/sharp-libvips-linux-x64': 1.1.0-rc4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.1':
+  '@img/sharp-linuxmusl-arm64@0.34.0-rc.0':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.1.0
+      '@img/sharp-libvips-linuxmusl-arm64': 1.1.0-rc4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.1':
+  '@img/sharp-linuxmusl-x64@0.34.0-rc.0':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.1.0
+      '@img/sharp-libvips-linuxmusl-x64': 1.1.0-rc4
     optional: true
 
-  '@img/sharp-wasm32@0.34.1':
+  '@img/sharp-wasm32@0.34.0-rc.0':
     dependencies:
       '@emnapi/runtime': 1.4.3
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.1':
+  '@img/sharp-win32-ia32@0.34.0-rc.0':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.1':
+  '@img/sharp-win32-x64@0.34.0-rc.0':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -1520,7 +1518,7 @@ snapshots:
     dependencies:
       decode-bmp: 0.2.1
       decode-ico: 0.4.1
-      sharp: 0.34.1
+      sharp: 0.34.0-rc.0
 
   '@napi-rs/nice-android-arm-eabi@1.0.1':
     optional: true
@@ -2026,7 +2024,7 @@ snapshots:
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       toad-cache: 3.7.0
 
   fastq@1.19.1:
@@ -2283,7 +2281,7 @@ snapshots:
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
-      semver: 7.7.1
+      semver: 7.7.2
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.1
@@ -2413,40 +2411,38 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  semver@7.7.1: {}
-
   semver@7.7.2: {}
 
   set-cookie-parser@2.7.1: {}
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.34.1:
+  sharp@0.34.0-rc.0:
     dependencies:
       color: 4.2.3
       detect-libc: 2.0.4
-      semver: 7.7.1
+      semver: 7.7.2
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.1
-      '@img/sharp-darwin-x64': 0.34.1
-      '@img/sharp-libvips-darwin-arm64': 1.1.0
-      '@img/sharp-libvips-darwin-x64': 1.1.0
-      '@img/sharp-libvips-linux-arm': 1.1.0
-      '@img/sharp-libvips-linux-arm64': 1.1.0
-      '@img/sharp-libvips-linux-ppc64': 1.1.0
-      '@img/sharp-libvips-linux-s390x': 1.1.0
-      '@img/sharp-libvips-linux-x64': 1.1.0
-      '@img/sharp-libvips-linuxmusl-arm64': 1.1.0
-      '@img/sharp-libvips-linuxmusl-x64': 1.1.0
-      '@img/sharp-linux-arm': 0.34.1
-      '@img/sharp-linux-arm64': 0.34.1
-      '@img/sharp-linux-s390x': 0.34.1
-      '@img/sharp-linux-x64': 0.34.1
-      '@img/sharp-linuxmusl-arm64': 0.34.1
-      '@img/sharp-linuxmusl-x64': 0.34.1
-      '@img/sharp-wasm32': 0.34.1
-      '@img/sharp-win32-ia32': 0.34.1
-      '@img/sharp-win32-x64': 0.34.1
+      '@img/sharp-darwin-arm64': 0.34.0-rc.0
+      '@img/sharp-darwin-x64': 0.34.0-rc.0
+      '@img/sharp-libvips-darwin-arm64': 1.1.0-rc4
+      '@img/sharp-libvips-darwin-x64': 1.1.0-rc4
+      '@img/sharp-libvips-linux-arm': 1.1.0-rc4.1
+      '@img/sharp-libvips-linux-arm64': 1.1.0-rc4
+      '@img/sharp-libvips-linux-ppc64': 1.1.0-rc4
+      '@img/sharp-libvips-linux-s390x': 1.1.0-rc4
+      '@img/sharp-libvips-linux-x64': 1.1.0-rc4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.1.0-rc4
+      '@img/sharp-libvips-linuxmusl-x64': 1.1.0-rc4
+      '@img/sharp-linux-arm': 0.34.0-rc.0
+      '@img/sharp-linux-arm64': 0.34.0-rc.0
+      '@img/sharp-linux-s390x': 0.34.0-rc.0
+      '@img/sharp-linux-x64': 0.34.0-rc.0
+      '@img/sharp-linuxmusl-arm64': 0.34.0-rc.0
+      '@img/sharp-linuxmusl-x64': 0.34.0-rc.0
+      '@img/sharp-wasm32': 0.34.0-rc.0
+      '@img/sharp-win32-ia32': 0.34.0-rc.0
+      '@img/sharp-win32-x64': 0.34.0-rc.0
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/image-processor.ts
+++ b/src/image-processor.ts
@@ -23,7 +23,6 @@ export const webpDefault: sharp.WebpOptions = {
     smartSubsample: true,
     mixed: true,
     effort: 2,
-    loop: 0,
 };
 
 export function convertToWebpStream(path: string, width: number, height: number, options: sharp.WebpOptions = webpDefault): IImageStream {


### PR DESCRIPTION
downgrade sharp to 0.34.0-rc.0
v0.34.2が出るまでこのバージョンにする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - WebP画像変換時のオプションから`loop: 0`設定を削除しました。

- **その他**
  - 依存パッケージ`sharp`のバージョンが`0.34.0-rc.0`に統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->